### PR TITLE
Fixed installation of header files and exporting of targets.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,9 +244,6 @@ generate_export_header(cmr EXPORT_FILE_NAME ${CMAKE_CURRENT_BINARY_DIR}/cmr/expo
 # Add an alias so that library can be used inside the build tree.
 add_library(CMR::cmr ALIAS cmr)
 
-# This is required so that the exported target has the name CMR and not just cmr.
-set_target_properties(cmr PROPERTIES EXPORT_NAME CMR)
-
 # Hide non-exported symbols in shared library.
 set_target_properties(cmr PROPERTIES CXX_VISIBILITY_PRESET hidden)
 set_target_properties(cmr PROPERTIES VISIBILITY_INLINES_HIDDEN 1)
@@ -296,8 +293,11 @@ install(TARGETS cmr
       DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
-install(DIRECTORY include
+# Install header files.
+install(DIRECTORY include/cmr
    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES ${CMAKE_BINARY_DIR}/cmr/config.h ${CMAKE_BINARY_DIR}/cmr/export.h
+   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cmr)
 
 # Export the targets to a script.
 set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/cmr/)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -23,6 +23,7 @@ if(DOXYGEN_FOUND)
   doxygen_add_docs(doc
     ${CMAKE_CURRENT_SOURCE_DIR}/index.md
     ${CMAKE_CURRENT_SOURCE_DIR}/balanced.md
+    ${CMAKE_CURRENT_SOURCE_DIR}/build.md
     ${CMAKE_CURRENT_SOURCE_DIR}/camion.md
     ${CMAKE_CURRENT_SOURCE_DIR}/changes.md
     ${CMAKE_CURRENT_SOURCE_DIR}/consecutive-ones.md

--- a/doc/index.md
+++ b/doc/index.md
@@ -33,7 +33,7 @@ The following matrix/matroid classes are **planned**:
 # Installation and Usage #
 
 The library can be found on [github](https://github.com/discopt/cmr/), or directly as a [ZIP Archive](https://github.com/discopt/cmr/archive/refs/heads/master.zip).
-The functionality can be used via command-line tools or via its C interface.
+The functionality can be used via command-line tools or via its C interface (see [build instructions](\ref build) for more information).
 There is one executable per matrix/matroid class.
 Its documentation and that of the interface can be found on the respective pages.
 The executables accept several \ref file-formats.


### PR DESCRIPTION
- There was a bug that actually caused installation to PREFIX/include/include/cmr/, which does not make sense at all.
- There was a mixture of cmake code using (imported) targets CMR::cmr and CMR::CMR. I chose the former and unified the code.
- To make this transparent, I also added a build page to the doxygen documentation.