### PR TITLE
Two (independent) fixes

### DIFF
--- a/include/cmr/matrix.h
+++ b/include/cmr/matrix.h
@@ -557,6 +557,51 @@ CMR_ERROR CMRchrmatCreateFromSparseStream(
 );
 
 /**
+ * \brief Reads a double matrix from a file name \p fileName in sparse format.
+ *
+ * Returns \ref CMR_ERROR_INPUT in case of errors. In this case, *\p presult will be \c NULL. Expects that the file
+ * contains only the matrix and no additional data.
+ */
+
+CMR_EXPORT
+CMR_ERROR CMRdblmatCreateFromSparseFile(
+  CMR* cmr,               /**< \ref CMR environment. */
+  const char* fileName,   /**< File stream to read from. */
+  const char* stdinName,  /**< If not \c NULL, indicates which file name represents stdin. */
+  CMR_DBLMAT** presult    /**< Pointer for storing the matrix. */
+);
+
+/**
+ * \brief Reads an int matrix from a file name \p fileName in sparse format.
+ *
+ * Returns \ref CMR_ERROR_INPUT in case of errors. In this case, *\p presult will be \c NULL. Expects that the file
+ * contains only the matrix and no additional data.
+ */
+
+CMR_EXPORT
+CMR_ERROR CMRintmatCreateFromSparseFile(
+  CMR* cmr,               /**< \ref CMR environment. */
+  const char* fileName,   /**< File stream to read from. */
+  const char* stdinName,  /**< If not \c NULL, indicates which file name represents stdin. */
+  CMR_INTMAT** presult    /**< Pointer for storing the matrix. */
+);
+
+/**
+ * \brief Reads a char matrix from a file name \p fileName in sparse format.
+ *
+ * Returns \ref CMR_ERROR_INPUT in case of errors. In this case, *\p presult will be \c NULL. Expects that the file
+ * contains only the matrix and no additional data.
+ */
+
+CMR_EXPORT
+CMR_ERROR CMRchrmatCreateFromSparseFile(
+  CMR* cmr,               /**< \ref CMR environment. */
+  const char* fileName,   /**< File stream to read from. */
+  const char* stdinName,  /**< If not \c NULL, indicates which file name represents stdin. */
+  CMR_CHRMAT** presult    /**< Pointer for storing the matrix. */
+);
+
+/**
  * \brief Reads a double matrix from a file \p stream in dense format.
  *
  * Returns \ref CMR_ERROR_INPUT in case of errors. In this case, *\p presult will be \c NULL.
@@ -593,6 +638,51 @@ CMR_ERROR CMRchrmatCreateFromDenseStream(
   CMR* cmr,             /**< \ref CMR environment. */
   FILE* stream,         /**< File stream to read from. */
   CMR_CHRMAT** presult  /**< Pointer for storing the matrix. */
+);
+
+/**
+ * \brief Reads a double matrix from a file name \p fileName in dense format.
+ *
+ * Returns \ref CMR_ERROR_INPUT in case of errors. In this case, *\p presult will be \c NULL. Expects that the file
+ * contains only the matrix and no additional data.
+ */
+
+CMR_EXPORT
+CMR_ERROR CMRdblmatCreateFromDenseFile(
+  CMR* cmr,               /**< \ref CMR environment. */
+  const char* fileName,   /**< File stream to read from. */
+  const char* stdinName,  /**< If not \c NULL, indicates which file name represents stdin. */
+  CMR_DBLMAT** presult    /**< Pointer for storing the matrix. */
+);
+
+/**
+ * \brief Reads an int matrix from a file name \p fileName in dense format.
+ *
+ * Returns \ref CMR_ERROR_INPUT in case of errors. In this case, *\p presult will be \c NULL. Expects that the file
+ * contains only the matrix and no additional data.
+ */
+
+CMR_EXPORT
+CMR_ERROR CMRintmatCreateFromDenseFile(
+  CMR* cmr,               /**< \ref CMR environment. */
+  const char* fileName,   /**< File stream to read from. */
+  const char* stdinName,  /**< If not \c NULL, indicates which file name represents stdin. */
+  CMR_INTMAT** presult    /**< Pointer for storing the matrix. */
+);
+
+/**
+ * \brief Reads a char matrix from a file name \p fileName in dense format.
+ *
+ * Returns \ref CMR_ERROR_INPUT in case of errors. In this case, *\p presult will be \c NULL. Expects that the file
+ * contains only the matrix and no additional data.
+ */
+
+CMR_EXPORT
+CMR_ERROR CMRchrmatCreateFromDenseFile(
+  CMR* cmr,               /**< \ref CMR environment. */
+  const char* fileName,   /**< File stream to read from. */
+  const char* stdinName,  /**< If not \c NULL, indicates which file name represents stdin. */
+  CMR_CHRMAT** presult    /**< Pointer for storing the matrix. */
 );
 
 /**

--- a/src/cmr/matrix.c
+++ b/src/cmr/matrix.c
@@ -1301,6 +1301,102 @@ CMR_ERROR CMRchrmatCreateFromSparseStream(CMR* cmr, FILE* stream, CMR_CHRMAT** p
   return CMR_OKAY;
 }
 
+CMR_ERROR CMRdblmatCreateFromSparseFile(CMR* cmr, const char* fileName, const char* stdinName, CMR_DBLMAT** presult)
+{
+  FILE* inputFile = (!stdinName || strcmp(fileName, stdinName)) ? fopen(fileName, "r") : stdin;
+  if (!inputFile)
+  {
+    CMRraiseErrorMessage(cmr, "Could not open file <%s>.", fileName);
+    return CMR_ERROR_INPUT;
+  }
+
+  CMR_ERROR error = CMRdblmatCreateFromSparseStream(cmr, inputFile, presult);
+  if (!error)
+  {
+    /* Attempt to read another token. */
+    char token[16+4];
+    size_t numRead = fscanf(inputFile, "%16s", token);
+    if (numRead > 0 && strlen(token))
+    {
+      if (strlen(token) == 16)
+        strcat(token, "...");
+      CMRraiseErrorMessage(cmr, "Found unexpected token \"%s\" after having read a *sparse* %lux%lu matrix with %lu nonzeros.",
+        token, (*presult)->numRows, (*presult)->numColumns, (*presult)->numNonzeros);
+      CMRdblmatFree(cmr, presult);
+      error = CMR_ERROR_INPUT;
+    }
+  }
+
+  if (inputFile != stdin)
+    fclose(inputFile);
+
+  return error;
+}
+
+CMR_ERROR CMRintmatCreateFromSparseFile(CMR* cmr, const char* fileName, const char* stdinName, CMR_INTMAT** presult)
+{
+  FILE* inputFile = (!stdinName || strcmp(fileName, stdinName)) ? fopen(fileName, "r") : stdin;
+  if (!inputFile)
+  {
+    CMRraiseErrorMessage(cmr, "Could not open file <%s>.", fileName);
+    return CMR_ERROR_INPUT;
+  }
+
+  CMR_ERROR error = CMRintmatCreateFromSparseStream(cmr, inputFile, presult);
+  if (!error)
+  {
+    /* Attempt to read another token. */
+    char token[16+4];
+    size_t numRead = fscanf(inputFile, "%16s", token);
+    if (numRead > 0 && strlen(token))
+    {
+      if (strlen(token) == 16)
+        strcat(token, "...");
+      CMRraiseErrorMessage(cmr, "Found unexpected token \"%s\" after having read a *sparse* %lux%lu matrix with %lu nonzeros.",
+        token, (*presult)->numRows, (*presult)->numColumns, (*presult)->numNonzeros);
+      CMRintmatFree(cmr, presult);
+      error = CMR_ERROR_INPUT;
+    }
+  }
+
+  if (inputFile != stdin)
+    fclose(inputFile);
+
+  return error;
+}
+
+CMR_ERROR CMRchrmatCreateFromSparseFile(CMR* cmr, const char* fileName, const char* stdinName, CMR_CHRMAT** presult)
+{
+  FILE* inputFile = (!stdinName || strcmp(fileName, stdinName)) ? fopen(fileName, "r") : stdin;
+  if (!inputFile)
+  {
+    CMRraiseErrorMessage(cmr, "Could not open file <%s>.", fileName);
+    return CMR_ERROR_INPUT;
+  }
+
+  CMR_ERROR error = CMRchrmatCreateFromSparseStream(cmr, inputFile, presult);
+  if (!error)
+  {
+    /* Attempt to read another token. */
+    char token[16+4];
+    size_t numRead = fscanf(inputFile, "%16s", token);
+    if (numRead > 0 && strlen(token))
+    {
+      if (strlen(token) == 16)
+        strcat(token, "...");
+      CMRraiseErrorMessage(cmr, "Found unexpected token \"%s\" after having read a *sparse* %lux%lu matrix with %lu nonzeros.",
+        token, (*presult)->numRows, (*presult)->numColumns, (*presult)->numNonzeros);
+      CMRchrmatFree(cmr, presult);
+      error = CMR_ERROR_INPUT;
+    }
+  }
+
+  if (inputFile != stdin)
+    fclose(inputFile);
+
+  return error;
+}
+
 CMR_ERROR CMRdblmatCreateFromDenseStream(CMR* cmr, FILE* stream, CMR_DBLMAT** presult)
 {
   assert(cmr);
@@ -1515,6 +1611,102 @@ CMR_ERROR CMRchrmatCreateFromDenseStream(CMR* cmr, FILE* stream, CMR_CHRMAT** pr
   result->numNonzeros = entry;
 
   return CMR_OKAY;
+}
+
+CMR_ERROR CMRdblmatCreateFromDenseFile(CMR* cmr, const char* fileName, const char* stdinName, CMR_DBLMAT** presult)
+{
+  FILE* inputFile = (!stdinName || strcmp(fileName, stdinName)) ? fopen(fileName, "r") : stdin;
+  if (!inputFile)
+  {
+    CMRraiseErrorMessage(cmr, "Could not open file <%s>.", fileName);
+    return CMR_ERROR_INPUT;
+  }
+
+  CMR_ERROR error = CMRdblmatCreateFromDenseStream(cmr, inputFile, presult);
+  if (!error)
+  {
+    /* Attempt to read another token. */
+    char token[16+4];
+    size_t numRead = fscanf(inputFile, "%16s", token);
+    if (numRead > 0 && strlen(token))
+    {
+      if (strlen(token) == 16)
+        strcat(token, "...");
+      CMRraiseErrorMessage(cmr, "Found unexpected token \"%s\" after having read a *dense* %lux%lu matrix with %lu nonzeros.",
+        token, (*presult)->numRows, (*presult)->numColumns, (*presult)->numNonzeros);
+      CMRdblmatFree(cmr, presult);
+      error = CMR_ERROR_INPUT;
+    }
+  }
+
+  if (inputFile != stdin)
+    fclose(inputFile);
+
+  return error;
+}
+
+CMR_ERROR CMRintmatCreateFromDenseFile(CMR* cmr, const char* fileName, const char* stdinName, CMR_INTMAT** presult)
+{
+  FILE* inputFile = (!stdinName || strcmp(fileName, stdinName)) ? fopen(fileName, "r") : stdin;
+  if (!inputFile)
+  {
+    CMRraiseErrorMessage(cmr, "Could not open file <%s>.", fileName);
+    return CMR_ERROR_INPUT;
+  }
+
+  CMR_ERROR error = CMRintmatCreateFromDenseStream(cmr, inputFile, presult);
+  if (!error)
+  {
+    /* Attempt to read another token. */
+    char token[16+4];
+    size_t numRead = fscanf(inputFile, "%16s", token);
+    if (numRead > 0 && strlen(token))
+    {
+      if (strlen(token) == 16)
+        strcat(token, "...");
+      CMRraiseErrorMessage(cmr, "Found unexpected token \"%s\" after having read a *dense* %lux%lu matrix with %lu nonzeros.",
+        token, (*presult)->numRows, (*presult)->numColumns, (*presult)->numNonzeros);
+      CMRintmatFree(cmr, presult);
+      error = CMR_ERROR_INPUT;
+    }
+  }
+
+  if (inputFile != stdin)
+    fclose(inputFile);
+
+  return error;
+}
+
+CMR_ERROR CMRchrmatCreateFromDenseFile(CMR* cmr, const char* fileName, const char* stdinName, CMR_CHRMAT** presult)
+{
+  FILE* inputFile = (!stdinName || strcmp(fileName, stdinName)) ? fopen(fileName, "r") : stdin;
+  if (!inputFile)
+  {
+    CMRraiseErrorMessage(cmr, "Could not open file <%s>.", fileName);
+    return CMR_ERROR_INPUT;
+  }
+
+  CMR_ERROR error = CMRchrmatCreateFromDenseStream(cmr, inputFile, presult);
+  if (!error)
+  {
+    /* Attempt to read another token. */
+    char token[16+4];
+    size_t numRead = fscanf(inputFile, "%16s", token);
+    if (numRead > 0 && strlen(token))
+    {
+      if (strlen(token) == 16)
+        strcat(token, "...");
+      CMRraiseErrorMessage(cmr, "Found unexpected token \"%s\" after having read a *dense* %lux%lu matrix with %lu nonzeros.",
+        token, (*presult)->numRows, (*presult)->numColumns, (*presult)->numNonzeros);
+      CMRchrmatFree(cmr, presult);
+      error = CMR_ERROR_INPUT;
+    }
+  }
+
+  if (inputFile != stdin)
+    fclose(inputFile);
+
+  return error;
 }
 
 bool CMRdblmatCheckEqual(CMR_DBLMAT* matrix1, CMR_DBLMAT* matrix2)

--- a/src/main/network_main.c
+++ b/src/main/network_main.c
@@ -27,46 +27,72 @@ typedef enum
  */
 
 CMR_ERROR recognizeNetwork(
-  const char* inputFileName,            /**< File name of the input matrix (may be `-' for stdin). */
+  const char* inputMatrixFileName,      /**< File name of the input matrix (may be `-' for stdin). */
   FileFormat inputFormat,               /**< Format of the input matrix. */
-  bool conetwork,                       /**< Whether the input shall be checked for being conetwork instead of network. */
+  bool conetwork,                       /**< Whether the input shall be checked for being conetwork instead of
+                                         **  network. */
   const char* outputGraphFileName,      /**< File name of the output graph (may be NULL; may be `-' for stdout). */
   const char* outputTreeFileName,       /**< File name of the output tree (may be NULL; may be `-' for stdout). */
   const char* outputDotFileName,        /**< File name of the output dot file (may be NULL; may be `-' for stdout). */
-  const char* outputSubmatrixFileName,  /**< File name of the output non-(co)network submatrix (may be NULL; may be `-' for stdout). */
+  const char* outputSubmatrixFileName,  /**< File name of the output non-(co)network submatrix (may be NULL; may be `-'
+                                         **  for stdout). */
   bool printStats,                      /**< Whether to print statistics to stderr. */
-  double timeLimit                  /**< Time limit to impose. */
+  double timeLimit                      /**< Time limit to impose. */
 )
 {
-  clock_t readClock = clock();
-  FILE* inputFile = strcmp(inputFileName, "-") ? fopen(inputFileName, "r") : stdin;
-  if (!inputFile)
-    return CMR_ERROR_INPUT;
-
   CMR* cmr = NULL;
   CMR_CALL( CMRcreateEnvironment(&cmr) );
 
   /* Read matrix. */
 
   CMR_CHRMAT* matrix = NULL;
+  clock_t readClock = clock();
+  CMR_ERROR error = CMR_OKAY;
   if (inputFormat == FILEFORMAT_MATRIX_DENSE)
-    CMR_CALL( CMRchrmatCreateFromDenseStream(cmr, inputFile, &matrix) );
+    error = CMRchrmatCreateFromDenseFile(cmr, inputMatrixFileName, "-", &matrix);
   else if (inputFormat == FILEFORMAT_MATRIX_SPARSE)
-    CMR_CALL( CMRchrmatCreateFromSparseStream(cmr, inputFile, &matrix) );
-  if (inputFile != stdin)
-    fclose(inputFile);
+    error = CMRchrmatCreateFromSparseFile(cmr, inputMatrixFileName, "-", &matrix);
+  else
+    CMR_CALL(CMR_ERROR_INVALID);
+
+  if (error)
+  {
+    fprintf(stderr, "Input error: %s\n", CMRgetErrorMessage(cmr));
+    CMR_CALL( CMRfreeEnvironment(&cmr) );
+    return CMR_ERROR_INPUT;
+  }
+
   fprintf(stderr, "Read %lux%lu matrix with %lu nonzeros in %f seconds.\n", matrix->numRows, matrix->numColumns,
     matrix->numNonzeros, (clock() - readClock) * 1.0 / CLOCKS_PER_SEC);
 
-  /* Test for network. */
+  /* Test for being ternary first. */
+
+  CMR_SUBMAT* submatrix = NULL;
+  if (!CMRchrmatIsTernary(cmr, matrix, &submatrix))
+  {
+    CMR_CHRMAT* mat = NULL;
+    CMR_CALL( CMRchrmatZoomSubmat(cmr, matrix, submatrix, &mat) );
+    assert(mat->numRows == 1);
+    assert(mat->numColumns == 1);
+    assert(mat->numNonzeros == 1);
+    fprintf(stderr, "Matrix is NOT %sgraphic since it is not binary: entry at row %ld, column %ld is %d.\n",
+      conetwork ? "co" : "", submatrix->rows[0] + 1, submatrix->columns[0] + 1, mat->entryValues[0]);
+
+    CMR_CALL( CMRchrmatFree(cmr, &mat) );
+    CMR_CALL( CMRsubmatFree(cmr, &submatrix) );
+    CMR_CALL( CMRchrmatFree(cmr, &matrix) );
+    CMR_CALL( CMRfreeEnvironment(&cmr) );
+
+    return CMR_OKAY;
+  }
+
+  /* Test for being (co)network. */
 
   bool isCoNetwork;
   CMR_GRAPH* digraph = NULL;
   CMR_GRAPH_EDGE* rowEdges = NULL;
   CMR_GRAPH_EDGE* columnEdges = NULL;
   bool* edgesReversed = NULL;
-  CMR_SUBMAT* submatrix = NULL;
-
   CMR_NETWORK_STATISTICS stats;
   CMR_CALL( CMRstatsNetworkInit(&stats) );
   if (conetwork)
@@ -250,7 +276,10 @@ CMR_ERROR computeNetwork(
 {
   FILE* inputFile = strcmp(inputFileName, "-") ? fopen(inputFileName, "r") : stdin;
   if (!inputFile)
+  {
+    fprintf(stderr, "Input error: Could not open file <%s>.\n", inputFileName);
     return CMR_ERROR_INPUT;
+  }
 
   CMR* cmr = NULL;
   CMR_CALL( CMRcreateEnvironment(&cmr) );
@@ -549,7 +578,7 @@ int main(int argc, char** argv)
   switch (error)
   {
   case CMR_ERROR_INPUT:
-    puts("Input error.");
+    /* The actual function will have reported the details. */
     return EXIT_FAILURE;
   case CMR_ERROR_MEMORY:
     puts("Memory error.");

--- a/src/main/regular_main.c
+++ b/src/main/regular_main.c
@@ -29,40 +29,27 @@ CMR_ERROR testRegularity(
   double timeLimit                  /**< Time limit to impose. */
 )
 {
-  clock_t readClock = clock();
-  FILE* inputMatrixFile = strcmp(inputMatrixFileName, "-") ? fopen(inputMatrixFileName, "r") : stdin;
-  if (!inputMatrixFile)
-  {
-    fprintf(stderr, "Unable to open file <%s>\n", inputMatrixFileName);
-    return CMR_ERROR_INPUT;
-  }
-
   CMR* cmr = NULL;
   CMR_CALL( CMRcreateEnvironment(&cmr) );
 
   /* Read matrix. */
 
   CMR_CHRMAT* matrix = NULL;
-  CMR_ERROR error;
+  clock_t readClock = clock();
+  CMR_ERROR error = CMR_OKAY;
   if (inputFormat == FILEFORMAT_MATRIX_DENSE)
-  {
-    error = CMRchrmatCreateFromDenseStream(cmr, inputMatrixFile, &matrix);
-    if (error == CMR_ERROR_INPUT)
-      fprintf(stderr, "Error when reading dense matrix from <%s>: %s\n", inputMatrixFileName, CMRgetErrorMessage(cmr));
-  }
+    error = CMRchrmatCreateFromDenseFile(cmr, inputMatrixFileName, "-", &matrix);
   else if (inputFormat == FILEFORMAT_MATRIX_SPARSE)
-  {
-    error = CMRchrmatCreateFromSparseStream(cmr, inputMatrixFile, &matrix);
-    if (error == CMR_ERROR_INPUT)
-      fprintf(stderr, "Error when reading dense matrix from <%s>: %s\n", inputMatrixFileName, CMRgetErrorMessage(cmr));
-  }
+    error = CMRchrmatCreateFromSparseFile(cmr, inputMatrixFileName, "-", &matrix);
   else
-    assert(false);
+    CMR_CALL(CMR_ERROR_INVALID);
 
-  if (inputMatrixFile != stdin)
-    fclose(inputMatrixFile);
-
-  CMR_CALL(error);
+  if (error)
+  {
+    fprintf(stderr, "Input error: %s\n", CMRgetErrorMessage(cmr));
+    CMR_CALL( CMRfreeEnvironment(&cmr) );
+    return CMR_ERROR_INPUT;
+  }
 
   fprintf(stderr, "Read %lux%lu matrix with %lu nonzeros in %f seconds.\n", matrix->numRows, matrix->numColumns,
     matrix->numNonzeros, (clock() - readClock) * 1.0 / CLOCKS_PER_SEC);
@@ -210,7 +197,7 @@ int main(int argc, char** argv)
   switch (error)
   {
   case CMR_ERROR_INPUT:
-    puts("Input error.");
+    /* The actual function will have reported the details. */
     return EXIT_FAILURE;
   case CMR_ERROR_MEMORY:
     puts("Memory error.");

--- a/src/main/series_parallel_main.c
+++ b/src/main/series_parallel_main.c
@@ -24,23 +24,28 @@ CMR_ERROR recognizeSeriesParallel(
   double timeLimit                  /**< Time limit to impose. */
 )
 {
-  clock_t readClock = clock();
-  FILE* inputMatrixFile = strcmp(inputMatrixFileName, "-") ? fopen(inputMatrixFileName, "r") : stdin;
-  if (!inputMatrixFile)
-    return CMR_ERROR_INPUT;
-
   CMR* cmr = NULL;
   CMR_CALL( CMRcreateEnvironment(&cmr) );
 
   /* Read matrix. */
 
   CMR_CHRMAT* matrix = NULL;
+  clock_t readClock = clock();
+  CMR_ERROR error = CMR_OKAY;
   if (inputFormat == FILEFORMAT_MATRIX_DENSE)
-    CMR_CALL( CMRchrmatCreateFromDenseStream(cmr, inputMatrixFile, &matrix) );
+    error = CMRchrmatCreateFromDenseFile(cmr, inputMatrixFileName, "-", &matrix);
   else if (inputFormat == FILEFORMAT_MATRIX_SPARSE)
-    CMR_CALL( CMRchrmatCreateFromSparseStream(cmr, inputMatrixFile, &matrix) );
-  if (inputMatrixFile != stdin)
-    fclose(inputMatrixFile);
+    error = CMRchrmatCreateFromSparseFile(cmr, inputMatrixFileName, "-", &matrix);
+  else
+    CMR_CALL(CMR_ERROR_INVALID);
+
+  if (error)
+  {
+    fprintf(stderr, "Input error: %s\n", CMRgetErrorMessage(cmr));
+    CMR_CALL( CMRfreeEnvironment(&cmr) );
+    return CMR_ERROR_INPUT;
+  }
+
   fprintf(stderr, "Read %lux%lu matrix with %lu nonzeros in %f seconds.\n", matrix->numRows, matrix->numColumns,
     matrix->numNonzeros, (clock() - readClock) * 1.0 / CLOCKS_PER_SEC);
 
@@ -205,7 +210,7 @@ int main(int argc, char** argv)
   switch (error)
   {
   case CMR_ERROR_INPUT:
-    puts("Input error.");
+    /* The actual function will have reported the details. */
     return EXIT_FAILURE;
   case CMR_ERROR_MEMORY:
     puts("Memory error.");

--- a/src/main/tu_main.c
+++ b/src/main/tu_main.c
@@ -29,40 +29,27 @@ CMR_ERROR testTotalUnimodularity(
   double timeLimit                      /**< Time limit to impose. */
 )
 {
-  clock_t readClock = clock();
-  FILE* inputMatrixFile = strcmp(inputMatrixFileName, "-") ? fopen(inputMatrixFileName, "r") : stdin;
-  if (!inputMatrixFile)
-  {
-    fprintf(stderr, "Unable to open file <%s>\n", inputMatrixFileName);
-    return CMR_ERROR_INPUT;
-  }
-
   CMR* cmr = NULL;
   CMR_CALL( CMRcreateEnvironment(&cmr) );
 
   /* Read matrix. */
 
   CMR_CHRMAT* matrix = NULL;
-  CMR_ERROR error;
+  clock_t readClock = clock();
+  CMR_ERROR error = CMR_OKAY;
   if (inputFormat == FILEFORMAT_MATRIX_DENSE)
-  {
-    error = CMRchrmatCreateFromDenseStream(cmr, inputMatrixFile, &matrix);
-    if (error == CMR_ERROR_INPUT)
-      fprintf(stderr, "Error when reading dense matrix from <%s>: %s\n", inputMatrixFileName, CMRgetErrorMessage(cmr));
-  }
+    error = CMRchrmatCreateFromDenseFile(cmr, inputMatrixFileName, "-", &matrix);
   else if (inputFormat == FILEFORMAT_MATRIX_SPARSE)
-  {
-    error = CMRchrmatCreateFromSparseStream(cmr, inputMatrixFile, &matrix);
-    if (error == CMR_ERROR_INPUT)
-      fprintf(stderr, "Error when reading sparse matrix from <%s>: %s\n", inputMatrixFileName, CMRgetErrorMessage(cmr));
-  }
+    error = CMRchrmatCreateFromSparseFile(cmr, inputMatrixFileName, "-", &matrix);
   else
-    assert(false);
+    CMR_CALL(CMR_ERROR_INVALID);
 
-  if (inputMatrixFile != stdin)
-    fclose(inputMatrixFile);
-
-  CMR_CALL(error);
+  if (error)
+  {
+    fprintf(stderr, "Input error: %s\n", CMRgetErrorMessage(cmr));
+    CMR_CALL( CMRfreeEnvironment(&cmr) );
+    return CMR_ERROR_INPUT;
+  }
 
   fprintf(stderr, "Read %lux%lu matrix with %lu nonzeros in %f seconds.\n", matrix->numRows, matrix->numColumns,
     matrix->numNonzeros, (clock() - readClock) * 1.0 / CLOCKS_PER_SEC);
@@ -210,6 +197,7 @@ int main(int argc, char** argv)
   switch (error)
   {
   case CMR_ERROR_INPUT:
+    /* The actual function will have reported the details. */
     return EXIT_FAILURE;
   case CMR_ERROR_MEMORY:
     puts("Memory error.");


### PR DESCRIPTION
Fail after reading sparse/dense matrices from files if these contain more data. Test for binary/ternary before testing for graphicness/network.