### PR TITLE
src/cmr/regularity_internal.h: Add missing header

### DIFF
--- a/src/cmr/regularity_internal.h
+++ b/src/cmr/regularity_internal.h
@@ -1,6 +1,8 @@
 #ifndef CMR_REGULAR_INTERNAL_H
 #define CMR_REGULAR_INTERNAL_H
 
+#include <time.h>
+
 #include <cmr/regular.h>
 
 #include "matroid_internal.h"


### PR DESCRIPTION
Fixes #60 