### PR TITLE
89 segfault in enumerative balancedness test

### DIFF
--- a/include/cmr/matrix.h
+++ b/include/cmr/matrix.h
@@ -809,11 +809,11 @@ char* CMRchrmatConsistency(
 );
 
 /**
- * \brief Creates a submatrix of a double matrix as an explicit matrix.
+ * \brief Slices a \p submatrix of a double matrix.
  */
 
 CMR_EXPORT
-CMR_ERROR CMRdblmatZoomSubmat(
+CMR_ERROR CMRdblmatSlice(
   CMR* cmr,               /**< \ref CMR environment. */
   CMR_DBLMAT* matrix,     /**< A matrix */
   CMR_SUBMAT* submatrix,  /**< A submatrix of \p matrix. */
@@ -821,11 +821,11 @@ CMR_ERROR CMRdblmatZoomSubmat(
 );
 
 /**
- * \brief Creates a submatrix of an int matrix as an explicit matrix.
+ * \brief Slices a \p submatrix of an int matrix.
  */
 
 CMR_EXPORT
-CMR_ERROR CMRintmatZoomSubmat(
+CMR_ERROR CMRintmatSlice(
   CMR* cmr,               /**< \ref CMR environment. */
   CMR_INTMAT* matrix,     /**< A matrix */
   CMR_SUBMAT* submatrix,  /**< A submatrix of \p matrix. */
@@ -833,11 +833,11 @@ CMR_ERROR CMRintmatZoomSubmat(
 );
 
 /**
- * \brief Creates a submatrix of a char matrix as an explicit matrix.
+ * \brief Slices a \p submatrix of a char matrix.
  */
 
 CMR_EXPORT
-CMR_ERROR CMRchrmatZoomSubmat(
+CMR_ERROR CMRchrmatSlice(
   CMR* cmr,               /**< \ref CMR environment. */
   CMR_CHRMAT* matrix,     /**< A matrix */
   CMR_SUBMAT* submatrix,  /**< A submatrix of \p matrix. */

--- a/include/cmr/matrix.h
+++ b/include/cmr/matrix.h
@@ -79,16 +79,32 @@ CMR_ERROR CMRsubmatTranspose(
 );
 
 /**
- * \brief Returns the submatrix \p input as a submatrix of the \p reference submatrix.
+ * \brief Returns the submatrix \p input as a submatrix of the \p base submatrix.
  *
- * Assumes that \p input is a sub-submatrix of \p references, i.e., each row/column of \p input must also appear in
- * \p reference.
+ * Assumes that each row/column of \p input also appear in\p base. After the call \p *poutput will refer to the same
+ * rows/columns but from the viewpoint of \p base.
+ * Otherwise, \ref CMR_ERROR_INPUT is returned.
  */
 
 CMR_EXPORT
-CMR_ERROR CMRsubmatZoomSubmat(
+CMR_ERROR CMRsubmatSlice(
   CMR* cmr,               /**< \ref CMR environment. */
-  CMR_SUBMAT* reference,  /**< Reference submatrix. */
+  CMR_SUBMAT* base,       /**< Reference submatrix. */
+  CMR_SUBMAT* input,      /**< Input submatrix. */
+  CMR_SUBMAT** poutput    /**< Pointer for storing the output submatrix. */
+);
+
+/**
+ * \brief Returns the sub-submatrix \p input of \p base as a submatrix of its parent.
+ *
+ * The rows/columns of \p input are interpreted as those of \p base. After the call \p *poutput will refer to the saem
+ * rows/columns but as those of the parent.
+ */
+
+CMR_EXPORT
+CMR_ERROR CMRsubmatUnslice(
+  CMR* cmr,               /**< \ref CMR environment. */
+  CMR_SUBMAT* base,       /**< Reference submatrix. */
   CMR_SUBMAT* input,      /**< Input submatrix. */
   CMR_SUBMAT** poutput    /**< Pointer for storing the output submatrix. */
 );

--- a/src/cmr/balanced.c
+++ b/src/cmr/balanced.c
@@ -1,4 +1,4 @@
-// #define CMR_DEBUG /* Uncomment to debug */
+#define CMR_DEBUG /* Uncomment to debug */
 
 #include <cmr/balanced.h>
 
@@ -625,6 +625,7 @@ CMR_ERROR CMRbalancedTest(CMR* cmr, CMR_CHRMAT* matrix, bool* pisBalanced, CMR_S
 {
   assert(cmr);
   assert(matrix);
+  assert(pisBalanced);
 
   /* Initialize default params if not passed. */
   CMR_BALANCED_PARAMS localParams;
@@ -683,6 +684,7 @@ CMR_ERROR CMRbalancedTest(CMR* cmr, CMR_CHRMAT* matrix, bool* pisBalanced, CMR_S
       if (!*pisBalanced && psubmatrix)
       {
         CMR_SUBMAT* submatrix = *psubmatrix;
+        assert(submatrix);
         for (size_t row = 0; row < submatrix->numRows; ++row)
           submatrix->rows[row] = component->rowsToOriginal[submatrix->rows[row]];
         for (size_t column = 0; column < submatrix->numColumns; ++column)

--- a/src/cmr/balanced.c
+++ b/src/cmr/balanced.c
@@ -578,8 +578,8 @@ CMR_ERROR balancedTestConnected(
       return CMR_ERROR_TIMEOUT;
     }
 
-    CMR_SUBMAT* submatrix = NULL;
-    error = balancedTestChooseAlgorithm(cmr, reducedMatrix, pisBalanced, psubmatrix ? &submatrix : NULL, params,
+    CMR_SUBMAT* submatrixOfReduced = NULL;
+    error = balancedTestChooseAlgorithm(cmr, reducedMatrix, pisBalanced, psubmatrix ? &submatrixOfReduced : NULL, params,
       stats, timeLimit - time);
 
     if (error != CMR_ERROR_TIMEOUT)
@@ -590,10 +590,10 @@ CMR_ERROR balancedTestConnected(
       CMRdbgMsg(4, "Matrix %s balanced.\n", (*pisBalanced) ? "IS" : "is NOT" );
 
       /* Turn the submatrix of the reduced matrix into a submatrix of the input matrix. */
-      if (submatrix)
+      if (submatrixOfReduced)
       {
-        CMRsubmatZoomSubmat(cmr, reducedSubmatrix, submatrix, psubmatrix);
-        CMR_CALL( CMRsubmatFree(cmr, &submatrix) );
+        CMR_CALL( CMRsubmatUnslice(cmr, reducedSubmatrix, submatrixOfReduced, psubmatrix) );
+        CMR_CALL( CMRsubmatFree(cmr, &submatrixOfReduced) );
       }
     }
 

--- a/src/cmr/matrix.c
+++ b/src/cmr/matrix.c
@@ -73,10 +73,10 @@ CMR_ERROR CMRsubmatTranspose(CMR_SUBMAT* submatrix)
   return CMR_OKAY;
 }
 
-CMR_ERROR CMRsubmatZoomSubmat(CMR* cmr, CMR_SUBMAT* reference, CMR_SUBMAT* input, CMR_SUBMAT** poutput)
+CMR_ERROR CMRsubmatSlice(CMR* cmr, CMR_SUBMAT* base, CMR_SUBMAT* input, CMR_SUBMAT** poutput)
 {
   assert(cmr);
-  assert(reference);
+  assert(base);
   assert(input);
   assert(poutput);
 
@@ -85,9 +85,9 @@ CMR_ERROR CMRsubmatZoomSubmat(CMR* cmr, CMR_SUBMAT* reference, CMR_SUBMAT* input
 
   /* Create reverse row mapping. */
   size_t numRows = 0;
-  for (size_t r = 0; r < reference->numRows; ++r)
+  for (size_t r = 0; r < base->numRows; ++r)
   {
-    size_t row = reference->rows[r];
+    size_t row = base->rows[r];
     numRows = row > numRows ? row : numRows;
   }
   ++numRows;
@@ -95,14 +95,14 @@ CMR_ERROR CMRsubmatZoomSubmat(CMR* cmr, CMR_SUBMAT* reference, CMR_SUBMAT* input
   CMR_CALL( CMRallocStackArray(cmr, &reverseRows, numRows) );
   for (size_t row = 0; row < numRows; ++row)
     reverseRows[row] = SIZE_MAX;
-  for (size_t r = 0; r < reference->numRows; ++r)
-    reverseRows[reference->rows[r]] = r;
+  for (size_t r = 0; r < base->numRows; ++r)
+    reverseRows[base->rows[r]] = r;
 
   /* Create reverse column mapping. */
   size_t numColumns = 0;
-  for (size_t c = 0; c < reference->numColumns; ++c)
+  for (size_t c = 0; c < base->numColumns; ++c)
   {
-    size_t column = reference->columns[c];
+    size_t column = base->columns[c];
     numColumns = column > numColumns ? column : numColumns;
   }
   ++numColumns;
@@ -110,8 +110,8 @@ CMR_ERROR CMRsubmatZoomSubmat(CMR* cmr, CMR_SUBMAT* reference, CMR_SUBMAT* input
   CMR_CALL( CMRallocStackArray(cmr, &reverseColumns, numColumns) );
   for (size_t column = 0; column < numColumns; ++column)
     reverseColumns[column] = SIZE_MAX;
-  for (size_t c = 0; c < reference->numColumns; ++c)
-    reverseColumns[reference->columns[c]] = c;
+  for (size_t c = 0; c < base->numColumns; ++c)
+    reverseColumns[base->columns[c]] = c;
 
   /* Fill submatrix. */
   for (size_t r = 0; r < input->numRows; ++r)
@@ -148,6 +148,26 @@ CMR_ERROR CMRsubmatZoomSubmat(CMR* cmr, CMR_SUBMAT* reference, CMR_SUBMAT* input
 
   return CMR_OKAY;
 }
+
+CMR_ERROR CMRsubmatUnslice(CMR* cmr, CMR_SUBMAT* base, CMR_SUBMAT* input, CMR_SUBMAT** poutput)
+{
+  assert(cmr);
+  assert(base);
+  assert(input);
+  assert(poutput);
+
+  CMR_CALL( CMRsubmatCreate(cmr, input->numRows, input->numColumns, poutput) );
+  CMR_SUBMAT* output = *poutput;
+
+  for (size_t row = 0; row < input->numRows; ++row)
+    output->rows[row] = base->rows[input->rows[row]];
+
+  for (size_t column = 0; column < input->numColumns; ++column)
+    output->columns[column] = base->columns[input->columns[column]];
+
+  return CMR_OKAY;
+}
+
 
 CMR_ERROR CMRsubmatPrint(CMR* cmr, CMR_SUBMAT* submatrix, size_t numRows, size_t numColumns, FILE* stream)
 {

--- a/src/cmr/seymour.c
+++ b/src/cmr/seymour.c
@@ -874,7 +874,13 @@ CMR_ERROR updateChildMatrix(
     columns[column] = CMRelementToColumnIndex(parent->childColumnsToParent[childIndex][column]);
   }
 
-  CMR_CALL( CMRchrmatFilter(cmr, parent->matrix, child->numRows, rows, child->numColumns, columns, &child->matrix) );
+  /* Create submatrix is on the stack. */
+  CMR_SUBMAT submat;
+  submat.numRows = child->numRows;
+  submat.numColumns = child->numColumns;
+  submat.rows = rows;
+  submat.columns = columns;
+  CMR_CALL( CMRchrmatSlice(cmr, parent->matrix, &submat, &child->matrix) );
 
   CMR_CALL( CMRfreeStackArray(cmr, &columns) );
   CMR_CALL( CMRfreeStackArray(cmr, &rows) );
@@ -1065,7 +1071,7 @@ CMR_ERROR CMRseymourUpdateSeriesParallel(CMR* cmr, CMR_SEYMOUR_NODE* node, CMR_S
   CMR_CALL( CMRseymourSetNumChildren(cmr, node, 1) );
 
   CMR_CHRMAT* childMatrix = NULL;
-  CMR_CALL( CMRchrmatZoomSubmat(cmr, node->matrix, reducedSubmatrix, &childMatrix) );
+  CMR_CALL( CMRchrmatSlice(cmr, node->matrix, reducedSubmatrix, &childMatrix) );
   CMR_CALL( createNode(cmr, &node->children[0], node->isTernary, CMR_SEYMOUR_NODE_TYPE_UNKNOWN, childMatrix->numRows,
     childMatrix->numColumns) );
   node->children[0]->matrix = childMatrix;

--- a/src/main/graphic_main.c
+++ b/src/main/graphic_main.c
@@ -72,7 +72,7 @@ CMR_ERROR recognizeGraphic(
   if (!CMRchrmatIsBinary(cmr, matrix, &submatrix))
   {
     CMR_CHRMAT* mat = NULL;
-    CMR_CALL( CMRchrmatZoomSubmat(cmr, matrix, submatrix, &mat) );
+    CMR_CALL( CMRchrmatSlice(cmr, matrix, submatrix, &mat) );
     assert(mat->numRows == 1);
     assert(mat->numColumns == 1);
     assert(mat->numNonzeros == 1);

--- a/src/main/matrix_main.c
+++ b/src/main/matrix_main.c
@@ -177,7 +177,7 @@ CMR_ERROR runDbl(
     }
 
     explicitSubmatrix = NULL;
-    CMR_CALL( CMRdblmatZoomSubmat(cmr, matrix, submatrix, &explicitSubmatrix) );
+    CMR_CALL( CMRdblmatSlice(cmr, matrix, submatrix, &explicitSubmatrix) );
     CMR_CALL( CMRsubmatFree(cmr, &submatrix) );
   }
   else
@@ -282,7 +282,7 @@ CMR_ERROR runInt(
       }
 
       explicitSubmatrix = NULL;
-      CMR_CALL( CMRintmatZoomSubmat(cmr, matrix, submatrix, &explicitSubmatrix) );
+      CMR_CALL( CMRintmatSlice(cmr, matrix, submatrix, &explicitSubmatrix) );
       CMR_CALL( CMRsubmatFree(cmr, &submatrix) );
     }
     else

--- a/src/main/network_main.c
+++ b/src/main/network_main.c
@@ -72,7 +72,7 @@ CMR_ERROR recognizeNetwork(
   if (!CMRchrmatIsTernary(cmr, matrix, &submatrix))
   {
     CMR_CHRMAT* mat = NULL;
-    CMR_CALL( CMRchrmatZoomSubmat(cmr, matrix, submatrix, &mat) );
+    CMR_CALL( CMRchrmatSlice(cmr, matrix, submatrix, &mat) );
     assert(mat->numRows == 1);
     assert(mat->numColumns == 1);
     assert(mat->numNonzeros == 1);

--- a/src/main/tu_main.c
+++ b/src/main/tu_main.c
@@ -85,7 +85,7 @@ CMR_ERROR testTotalUnimodularity(
     /* Extract submatrix to compute its determinant. */
     CMR_CHRMAT* violator = NULL;
     int64_t determinant = 0;
-    CMR_CALL( CMRchrmatZoomSubmat(cmr, matrix, submatrix, &violator) );
+    CMR_CALL( CMRchrmatSlice(cmr, matrix, submatrix, &violator) );
     CMR_CALL( CMRchrmatDeterminant(cmr, violator, &determinant) );
     CMR_CALL( CMRchrmatFree(cmr, &violator) );
 

--- a/test/test_camion.cpp
+++ b/test/test_camion.cpp
@@ -48,7 +48,7 @@ TEST(Camion, Change)
   ASSERT_CMR_CALL( CMRcamionTestSigns(cmr, matrix, &alreadySigned, &submatrix, NULL, DBL_MAX) );
   ASSERT_FALSE(alreadySigned);
   ASSERT_TRUE(submatrix != NULL);
-  ASSERT_CMR_CALL( CMRchrmatZoomSubmat(cmr, matrix, submatrix, &violator) );
+  ASSERT_CMR_CALL( CMRchrmatSlice(cmr, matrix, submatrix, &violator) );
   ASSERT_TRUE(CMRchrmatCheckEqual(violator, checkViolator));
   ASSERT_CMR_CALL( CMRchrmatFree(cmr, &violator) );
   ASSERT_CMR_CALL( CMRsubmatFree(cmr, &submatrix) );

--- a/test/test_matrix.cpp
+++ b/test/test_matrix.cpp
@@ -287,7 +287,7 @@ TEST(Matrix, Submatrix)
   submatrix->columns[2] = 6;
 
   CMR_CHRMAT* result = NULL;
-  ASSERT_CMR_CALL( CMRchrmatZoomSubmat(cmr, matrix, submatrix, &result) );
+  ASSERT_CMR_CALL( CMRchrmatSlice(cmr, matrix, submatrix, &result) );
 
   CMRchrmatPrintDense(cmr, result, stdout, '0', true);
   

--- a/test/test_series_parallel.cpp
+++ b/test/test_series_parallel.cpp
@@ -172,7 +172,7 @@ TEST(SeriesParallel, BinaryShortWheel)
   ASSERT_EQ( numOperations, 8UL );
 
   CMR_CHRMAT* wheelMatrix = NULL;
-  ASSERT_CMR_CALL( CMRchrmatZoomSubmat(cmr, matrix, wheelSubmatrix, &wheelMatrix) );
+  ASSERT_CMR_CALL( CMRchrmatSlice(cmr, matrix, wheelSubmatrix, &wheelMatrix) );
 
   CMRchrmatPrintDense(cmr, wheelMatrix, stdout, '0', true);
   
@@ -224,7 +224,7 @@ TEST(SeriesParallel, BinaryLongWheel)
   }
   
   CMR_CHRMAT* wheelMatrix = NULL;
-  ASSERT_CMR_CALL( CMRchrmatZoomSubmat(cmr, matrix, wheelSubmatrix, &wheelMatrix) );
+  ASSERT_CMR_CALL( CMRchrmatSlice(cmr, matrix, wheelSubmatrix, &wheelMatrix) );
 
   CMRchrmatPrintDense(cmr, wheelMatrix, stdout, '0', true);
   
@@ -276,7 +276,7 @@ TEST(SeriesParallel, BinarySpecialWheel)
   }
 
   CMR_CHRMAT* wheelMatrix = NULL;
-  ASSERT_CMR_CALL( CMRchrmatZoomSubmat(cmr, matrix, wheelSubmatrix, &wheelMatrix) );
+  ASSERT_CMR_CALL( CMRchrmatSlice(cmr, matrix, wheelSubmatrix, &wheelMatrix) );
 
   CMRchrmatPrintDense(cmr, wheelMatrix, stdout, '0', true);
   
@@ -320,7 +320,7 @@ TEST(SeriesParallel, BinarySeparationFirstSearch)
   ASSERT_EQ( numReductions, 8UL );
 
 
-  ASSERT_CMR_CALL( CMRchrmatZoomSubmat(cmr, matrix, reducedSubmatrix, &reducedMatrix) );
+  ASSERT_CMR_CALL( CMRchrmatSlice(cmr, matrix, reducedSubmatrix, &reducedMatrix) );
 
   CMRchrmatPrintDense(cmr, matrix, stdout, '0', true);
 
@@ -426,7 +426,7 @@ TEST(SeriesParallel, BinaryWheelAfterSeparation)
   }
 
   CMR_CHRMAT* wheelMatrix = NULL;
-  ASSERT_CMR_CALL( CMRchrmatZoomSubmat(cmr, matrix, wheelSubmatrix, &wheelMatrix) );
+  ASSERT_CMR_CALL( CMRchrmatSlice(cmr, matrix, wheelSubmatrix, &wheelMatrix) );
 
   CMRchrmatPrintDense(cmr, wheelMatrix, stdout, '0', true);
   
@@ -504,7 +504,7 @@ TEST(SeriesParallel, TernaryNonbinary)
   }
 
   CMR_CHRMAT* violatorMatrix = NULL;
-  ASSERT_CMR_CALL( CMRchrmatZoomSubmat(cmr, matrix, violatorSubmatrix, &violatorMatrix) );
+  ASSERT_CMR_CALL( CMRchrmatSlice(cmr, matrix, violatorSubmatrix, &violatorMatrix) );
   ASSERT_EQ( violatorMatrix->numNonzeros, 4UL );
   int det = violatorMatrix->entryValues[0] * violatorMatrix->entryValues[3]
     - violatorMatrix->entryValues[1] * violatorMatrix->entryValues[2];
@@ -550,7 +550,7 @@ TEST(SeriesParallel, TernaryWheel)
   }
 
   CMR_CHRMAT* violatorMatrix = NULL;
-  ASSERT_CMR_CALL( CMRchrmatZoomSubmat(cmr, matrix, violatorSubmatrix, &violatorMatrix) );
+  ASSERT_CMR_CALL( CMRchrmatSlice(cmr, matrix, violatorSubmatrix, &violatorMatrix) );
   ASSERT_EQ( violatorMatrix->numNonzeros, 6UL );
 
   ASSERT_CMR_CALL( CMRchrmatPrintDense(cmr, violatorMatrix, stdout, '0', true) );
@@ -652,9 +652,9 @@ TEST(SeriesParallel, TernaryBadSeparation)
   CMR_CHRMAT* reducedMatrix = NULL;
   CMR_CHRMAT* violatorMatrix = NULL;
 
-  ASSERT_CMR_CALL( CMRchrmatZoomSubmat(cmr, matrix, reducedSubmatrix, &reducedMatrix) );
+  ASSERT_CMR_CALL( CMRchrmatSlice(cmr, matrix, reducedSubmatrix, &reducedMatrix) );
 
-  ASSERT_CMR_CALL( CMRchrmatZoomSubmat(cmr, reducedMatrix, violatorSubmatrix, &violatorMatrix) );
+  ASSERT_CMR_CALL( CMRchrmatSlice(cmr, reducedMatrix, violatorSubmatrix, &violatorMatrix) );
 
   CMRchrmatPrintDense(cmr, violatorMatrix, stdout, '0', true);
 


### PR DESCRIPTION
Refactored matrix slicing. These were renamed:

- `CMRchrmatZoomSubmat` is now `CMRchrmatSlice`
- `CMRintmatZoomSubmat` is now `CMRintmatSlice`
- `CMRdblmatZoomSubmat` is now `CMRdblmatSlice`
- `CMRsubmatZoomSubmat` is now `CMRsubmatSlice`

A new function `CMRsubmatUnslice` was added for reverting a slicing operation (on the level of indices).